### PR TITLE
Handle DISCONNECT packets without properties length field

### DIFF
--- a/src/packet/v5/disconnect_packet.rs
+++ b/src/packet/v5/disconnect_packet.rs
@@ -87,6 +87,9 @@ impl<'a, const MAX_PROPERTIES: usize> Packet<'a> for DisconnectPacket<'a, MAX_PR
             return Ok(());
         }
         self.disconnect_reason = buff_reader.read_u8()?;
+        if self.remain_len == 1 {
+            return Ok(());
+        }
         self.decode_properties(buff_reader)
     }
 


### PR DESCRIPTION
rust-mqtt currently can't parse DISCONNECT packets without a properties length field, and returns an "InsufficientBufferSize" error instead:

[TRACE] Received packet with len: 3 (rust_mqtt rust-mqtt-0.3.0/src/fmt.rs:112)
[TRACE] First byte of accepted packet: E0 (rust_mqtt rust-mqtt-0.3.0/src/fmt.rs:112)
[ERROR] [DECODE ERR]: InsufficientBufferSize (rust_mqtt rust-mqtt-0.3.0/src/fmt.rs:164)

Such packets are generated by mosquitto if there are no properties. For example, a session taken over disconnect consists of the bytes e0 01 8e.

MQ Telemetry Transport Protocol, Disconnect Req
    Header Flags: 0xe0, Message Type: Disconnect Req
        1110 .... = Message Type: Disconnect Req (14)
        .... 0000 = Reserved: 0
    Msg Len: 1
    Reason Code: Session taken over (142)

https://github.com/eclipse-mosquitto/mosquitto/blob/28f914788f6a23781d724d31a4d44e2616815964/lib/send_disconnect.c#L76-L79

So if there are no properties, even the properties length field is omitted.

I'm not sure if that's allowed, as
https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901028 says: "If there are no properties, this MUST be indicated by including a Property Length of zero". On the other hand,
https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901210 says: "If the Remaining Length is less than 2, a value of 0 is used.", so a remaining length of 1 seems to be allowed.

In any case, mosquitto is a rather popular MQTT server, so it would be nice if rust-mqtt understood these packets.